### PR TITLE
Removed seek related command in readme and src

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ This table shows some key binds
 | Decrease volume | - | General |
 | Skip to next track | n | General |
 | Skip to previous track | p | General |
-| Seek forwards | > | General |
-| Seek backwards | < | General |
 | Toggle repeat mode | r | General |
 | Move selection left | h \| \<Left Arrow Key>  | General |
 | Move selection down | j \| \<Down Arrow Key>  | General |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ This table shows some key binds
 | Skip to previous track | p | General |
 | Seek forwards | > | General |
 | Seek backwards | < | General |
-| Seek backwards | < | General |
 | Toggle repeat mode | r | General |
 | Move selection left | h \| \<Left Arrow Key>  | General |
 | Move selection down | j \| \<Down Arrow Key>  | General |

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -718,8 +718,6 @@ where
         vec!["Decrease volume", "-", "General"],
         vec!["Skip to next track", "n", "General"],
         vec!["Skip to previous track", "p", "General"],
-        vec!["Seek forwards", ">", "General"],
-        vec!["Seek backwards", "<", "General"],
         vec!["Toggle repeat mode", "r", "General"],
         vec!["Move selection left", "h | <Left Arrow Key> ", "General"],
         vec!["Move selection down", "j | <Down Arrow Key> ", "General"],


### PR DESCRIPTION
Since the current player does not support seek function. Removed description in both README.md and in app help page. 

PS: First commit fixes the duplicate row "Seek backwards" in README.md.

---
当前版本不支持seek，移除了位于README和help 里面和seek 有关的条目。

PS：第一个commit修复了 "Seek backwards" 在 README 中重复两次的问题。