### PR TITLE
Fix two bugs: no sound and crash on some songs

### DIFF
--- a/src/player/fetch.rs
+++ b/src/player/fetch.rs
@@ -1,6 +1,6 @@
 use std::io::prelude::*;
 use futures::channel::oneshot::Sender;
-use reqwest::header::{HOST, CACHE_CONTROL, PRAGMA, HeaderMap, UPGRADE_INSECURE_REQUESTS, ACCEPT, ACCEPT_ENCODING, USER_AGENT};
+use reqwest::header::{CACHE_CONTROL, PRAGMA, HeaderMap, UPGRADE_INSECURE_REQUESTS, ACCEPT, ACCEPT_ENCODING, USER_AGENT};
 use reqwest::Method;
 use tempfile::NamedTempFile;
 
@@ -14,7 +14,6 @@ pub async fn fetch_data(url: &str, buffer: NamedTempFile, tx: Sender<String>) ->
     headers.insert(CACHE_CONTROL, "no-cache".parse().unwrap());
     headers.insert(PRAGMA, "no-cache".parse().unwrap());
     headers.insert(UPGRADE_INSECURE_REQUESTS, "1".parse().unwrap());
-    headers.insert(HOST, "m7.music.126.net".parse().unwrap());
     headers.insert(ACCEPT, "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3".parse().unwrap());
     headers.insert(ACCEPT_ENCODING, "gzip,deflate".parse().unwrap());
     headers.insert(

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -36,6 +36,8 @@ pub struct Player {
     pub state: PlayerState,
     pub current: Option<Track>,
     pub sink: rodio::Sink,
+    pub stream: rodio::OutputStream,
+    pub stream_handle: rodio::OutputStreamHandle,
 }
 
 // player
@@ -57,7 +59,9 @@ impl Player {
         Player {
             state: PlayerState::Stopped,
             current: None,
-            sink: sink,
+            sink,
+            stream,
+            stream_handle,
             // endpoint: endpoint,
         }
     }
@@ -131,7 +135,7 @@ impl Player {
     pub fn start(&mut self) {
         let vol = self.sink.volume();
         self.sink.stop();
-        // self.sink = rodio::Sink::new(&self.endpoint);
+        self.sink = rodio::Sink::try_new(&self.stream_handle).unwrap();
         self.set_volume(vol);
     }
 


### PR DESCRIPTION
- No sound bug is caused by that OutputStream returned by rodio::OutputStream::try_default() is dropped immediately after Player::new() ends, so the sink attached to this OutputStream will not work.
- According to [this issue](https://github.com/RustAudio/rodio/issues/315), currently there is no way to unstopped a sink, so we have to allocate a new sink in Player->start()
- Random crash on some songs is caused that the HOST field of the request header does not match the URL. So we will get an error response instead of an mp3 file.

Changes I made:
- Store OutputStream in Player to keep it not dropped
- Store OutputStreamHandle in Player to allocate a new sink in Player->start()
- Delete the HOST field of the request header