### PR TITLE
Fix regex to handle repeating patterns in lyric & Add translated lyric support

### DIFF
--- a/src/model/lyric.rs
+++ b/src/model/lyric.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 pub struct LyricRes {
     pub code: i32,
     pub lrc: Lrc,
+    pub tlyric: Lrc
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
In some songs, the fetched lyrics are repeated in the timestamp part. For example, `song id=30951192`:

```
[01:12.40]今、会いに行くわ　Highway to hell.
[01:15.48]握りつぶせ弱気な　Hearts.
[01:17.98]やっとあなた見つけたわ　to Mind.
[01:25.43][03:54.86]冥界へと咲かせ転生の花
[01:30.75][04:00.43]眠りを呼び覚ます　冥界の底
[01:36.24][04:05.85]廻る運命が交差する　Border of the life.
[01:42.12][04:11.92]過去を掘り返すわ　jog my memories　終わりへ向かう
[01:50.45]You got LAST DESTINY in my heart.
[02:06.39]足下に散らばる色は
[02:11.43]私の心　混乱させた
```

To fix it, match timestamp parts one or multiple times in regex.

To add translated lyric support, combine `tlyrics`(translated lyrics) and `lrc`(raw lyrics) and sort them by time, and add a tiny time offset to the former one.